### PR TITLE
Update zipper.go

### DIFF
--- a/zipper.go
+++ b/zipper.go
@@ -3,10 +3,11 @@ package main;
 import(
   "flag"
   "fmt"
-  "./google"
-  "./bitdo"
-  "./isgd"
-  "./vgd"
+  
+  "github.com/bagwanpankaj/zipper/google"
+  "github.com/bagwanpankaj/zipper/bitdo"
+  "github.com/bagwanpankaj/zipper/isgd"
+  "github.com/bagwanpankaj/zipper/vgd"
 )
 
 func main(){


### PR DESCRIPTION
http://grokbase.com/t/gg/golang-nuts/1342gmye5v/go-nuts-proposal-ban-relative-import-paths

To be idiomatic, one should use canonical and not relative import paths. :)
