### PR TITLE
Fix missing err check and remove panic

### DIFF
--- a/google/google.go
+++ b/google/google.go
@@ -2,38 +2,41 @@
 package google
 
 import (
-  "bytes"
-  "encoding/json"
-  "errors"
-  "io/ioutil"
-  "net/http"
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io/ioutil"
+	"net/http"
 )
 
 // Shorten calls to shortener services with data provided and returns string
 // containing shortened url and error (if any)
 func Shorten(url, key string) (string, error) {
-  client := &http.Client{}
-  req, err := http.NewRequest("POST", "https://www.googleapis.com/urlshortener/v1/url?key="+key,
-    bytes.NewBufferString("{\"longUrl\": \""+url+"\"}"))
-  if err != nil {
-    panic(err)
-  }
-  req.Header.Add("Content-Type", "application/json")
-  resp, err := client.Do(req)
-  if resp.StatusCode != 200 {
-    return "", errors.New(resp.Status)
-  }
-  defer resp.Body.Close()
-  body, err := ioutil.ReadAll(resp.Body)
-  if err != nil {
-    return "", err
-  }
+	client := &http.Client{}
+	req, err := http.NewRequest("POST", "https://www.googleapis.com/urlshortener/v1/url?key="+key,
+		bytes.NewBufferString("{\"longUrl\": \""+url+"\"}"))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Add("Content-Type", "application/json")
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	if resp.StatusCode != 200 {
+		return "", errors.New(resp.Status)
+	}
+	defer resp.Body.Close()
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
 
-  var f interface{}
-  err = json.Unmarshal(body, &f)
-  if err != nil {
-    return "", err
-  }
-  shortUrl := f.(map[string]interface{})["id"].(string)
-  return shortUrl, nil
+	var f interface{}
+	err = json.Unmarshal(body, &f)
+	if err != nil {
+		return "", err
+	}
+	shortUrl := f.(map[string]interface{})["id"].(string)
+	return shortUrl, nil
 }


### PR DESCRIPTION
After `client.Do(req)`, the error is not checked, which could lead to panic if there is no network.
Also you shouldn't use `panic` in a library and let the client deal with the error.

Sorry for the huge diff but it seems you did not use `gofmt` to format your code. You can view the diff without the spaces by adding the param `w=0` in the url, like that https://github.com/bagwanpankaj/zipper/pull/4/files?w=0
